### PR TITLE
Undependent plugins which treated as built-in before

### DIFF
--- a/packages/dynapi-core/package.json
+++ b/packages/dynapi-core/package.json
@@ -17,11 +17,9 @@
     "framework"
   ],
   "dependencies": {
-    "@babel/core": "^7.0.0-beta.40",
-    "@babel/preset-env": "^7.0.0-beta.40",
-    "@babel/traverse": "^7.0.0-beta.40",
-    "@dynapi/plugin-debug": "^0.0.0",
-    "@dynapi/plugin-ignore-paths": "^0.0.0",
+    "@babel/core": "7.0.0-beta.46",
+    "@babel/preset-env": "7.0.0-beta.46",
+    "@babel/traverse": "7.0.0-beta.46",
     "chalk": "^2.1.0",
     "chokidar": "^2.0.0",
     "debug": "^3.0.1",

--- a/packages/dynapi-core/src/common/factory-options.js
+++ b/packages/dynapi-core/src/common/factory-options.js
@@ -25,22 +25,11 @@ FactoryOptions.from = function (opt) {
     options.routers.push(opt.router)
   }
 
-  // Fill router plugins
-  // Will be validated by RouterOptions
+  // Fill router plugins, options will be validated by RouterOptions
   options.routers.forEach(router => {
     router.rootdir = router.rootdir || options.rootdir
     router.src = (router.src || options.src || './')
     router.plugins = router.plugins || []
-
-    // Built-in plugin: ignore-paths
-    if (router.ignore) {
-      router.plugins.push(['ignore-paths', router.ignore])
-    }
-
-    // Built-in plugin: debug
-    if (router.debug) {
-      router.plugins.push(['debug', router.debug])
-    }
 
     // Fetch plugins
     if (router.plugins.length > 0) {

--- a/packages/dynapi-plugin-ignore-paths/test/fixtures/server.js
+++ b/packages/dynapi-plugin-ignore-paths/test/fixtures/server.js
@@ -1,5 +1,6 @@
 const connect = require('connect')
 const dynapi = require('dynapi')
+const pluginIngorePaths = require('../../lib')
 
 function createServer (opt = {}) {
   const app = connect()
@@ -9,7 +10,7 @@ function createServer (opt = {}) {
     router: {
       entry: './routes',
       plugins: [
-        opt.ignore ? ['ignore-paths', opt.ignore] : null
+        opt.ignore ? pluginIngorePaths(opt.ignore) : null
       ].filter(Boolean)
     }
   }))

--- a/packages/dynapi-plugin-ignore-paths/test/fixtures/server.js
+++ b/packages/dynapi-plugin-ignore-paths/test/fixtures/server.js
@@ -8,8 +8,9 @@ function createServer (opt = {}) {
     rootdir: __dirname,
     router: {
       entry: './routes',
-      plugins: opt.plugins,
-      ignore: opt.ignore
+      plugins: [
+        opt.ignore ? ['ignore-paths', opt.ignore] : null
+      ].filter(Boolean)
     }
   }))
 

--- a/packages/dynapi-plugin-ignore-paths/test/index.test.js
+++ b/packages/dynapi-plugin-ignore-paths/test/index.test.js
@@ -27,7 +27,7 @@ test('Check dynapi works', async t => {
 })
 
 test('Should ignore filename', async t => {
-  const server = request(await createServer({ plugins: [['ignore-paths', ['a']]] }))
+  const server = request(await createServer({ ignore: ['a'] }))
   const result = [0, 1, 1, 0, 1, 1, 0, 1]
   await runTest(t, server, result)
 })


### PR DESCRIPTION
## Reason

Since `v0.4.0-beta-1`, we moved some features into `plugins/` and treated them as standalone features which not dependents on `dynapi` itself to shrink bundle size as your choice.

Not long ago, we use `Lerna` to refactor the whole project (#1), one of the main reason is that now I can decoupling `Builder` from `dynapi` to standalone modules like `@dynapi/builder-babel`, `@dynapi/builder-typescript`, and only transform native `javascript` in `dynapi` or `@dynapi/core` in future.

## Changes

❌ No more plugin shortcut like:
```javascript
app.use(dynapi.factory({
  router: {
    debug: { prefix: 'request' }
  }
})
```

✅ but use:
```javascript
app.use(dynapi.factory({
  router: {
    plugins: [
      ['debug', { prefix: 'request' }]
    ]
  }
})
```

`dynapi` will resolve modules in these order:
- `@dynapi/plugin-${plugin_name}`
- `dynapi-plugin-${plugin_name}`